### PR TITLE
Fix: send plain string for text column, not link-format JSON

### DIFF
--- a/state-spending-monitor/fix_board_urls.py
+++ b/state-spending-monitor/fix_board_urls.py
@@ -175,7 +175,8 @@ def main():
         logger.info(f"    New: {change['new_url']}")
 
         if not dry_run:
-            value = json.dumps({"url": change['new_url'], "text": change['name']})
+            # Column is a text type — value must be a plain JSON string
+            value = json.dumps(change['new_url'])
             mutation = """
             mutation ($boardId: ID!, $itemId: ID!, $columnId: String!, $value: JSON!) {
               change_column_value(


### PR DESCRIPTION
The RHTP Specific URL column is type 'text', not 'link'. monday.com text columns expect a plain JSON string value, not {"url": ..., "text": ...}.

https://claude.ai/code/session_01Jb4NMoDrVnbedqC1ePiMYn