### PR TITLE
Fix Brotli gibberish: remove 'br' from Accept-Encoding

### DIFF
--- a/state-spending-monitor/url_monitor.py
+++ b/state-spending-monitor/url_monitor.py
@@ -86,7 +86,7 @@ class URLMonitor:
             ),
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
             'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate, br',
+            'Accept-Encoding': 'gzip, deflate',
             'Connection': 'keep-alive',
             'Upgrade-Insecure-Requests': '1',
             'Sec-Fetch-Dest': 'document',

--- a/state-spending-monitor/validate_urls.py
+++ b/state-spending-monitor/validate_urls.py
@@ -66,7 +66,7 @@ class URLValidator:
             ),
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
             'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate, br',
+            'Accept-Encoding': 'gzip, deflate',
             'Connection': 'keep-alive',
             'Upgrade-Insecure-Requests': '1',
             'Sec-Fetch-Dest': 'document',


### PR DESCRIPTION
Servers returned Brotli-compressed responses but requests library can't decompress Brotli without the brotli package. This caused binary gibberish in diffs for NJ, Utah, Wyoming, CMS, and others.

https://claude.ai/code/session_01Jb4NMoDrVnbedqC1ePiMYn