### PR TITLE
Newsletter: add link enrichment + rewrite prompt to match editorial s…

### DIFF
--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install requests anthropic
+        run: pip install requests anthropic beautifulsoup4 lxml pypdf
 
       - name: Generate newsletter
         working-directory: state-spending-monitor


### PR DESCRIPTION
…tyle

Link enrichment:
- Re-fetches each changed state's RHTP page during newsletter generation
- Extracts key links (PDFs, subpages, forms, media, keyword-matched)
- Follows up to 10 links per state, extracts content (HTML + PDF text)
- Passes enriched content to Claude for deep-link-rich newsletter output

Prompt rewrite (matching user's editorial preferences):
- Descriptive headline (not generic "Weekly Brief")
- Date slug as h2 subhead
- No <hr> line separators
- Bullet format with verb clauses ("Posted a...", "Published its...")
- State name in header only, then straight to bullets
- Full URLs displayed inline for deep links (shows geekiness)
- Direct quotes from source material
- Pull key content from linked pages directly into newsletter

https://claude.ai/code/session_01Jb4NMoDrVnbedqC1ePiMYn