### PR TITLE
Fix gibberish detection: check non-ASCII ratio instead of non-printable

### DIFF
--- a/state-spending-monitor/newsletter.py
+++ b/state-spending-monitor/newsletter.py
@@ -135,15 +135,17 @@ def fetch_weekly_changes(token: str, repo: str, lookback_days: int = 7) -> List[
 
 
 def is_binary_garbage(text: str) -> bool:
-    """Detect if text looks like binary/Brotli gibberish rather than real content."""
+    """Detect if text looks like binary/Brotli gibberish rather than real content.
+
+    BeautifulSoup converts binary data into Unicode characters that Python
+    considers 'printable'. We check non-ASCII ratio instead — real .gov pages
+    are overwhelmingly ASCII.
+    """
     if not text or len(text) < 50:
         return False
     sample = text[:2000]
-    non_printable = sum(
-        1 for c in sample
-        if not c.isprintable() and c not in '\n\r\t'
-    )
-    return (non_printable / len(sample)) > 0.1
+    non_ascii = sum(1 for c in sample if ord(c) > 127)
+    return (non_ascii / len(sample)) > 0.15
 
 
 def parse_issue_changes(body: str) -> List[Dict]:

--- a/state-spending-monitor/url_monitor.py
+++ b/state-spending-monitor/url_monitor.py
@@ -350,18 +350,16 @@ class URLMonitor:
     def is_binary_garbage(text: str) -> bool:
         """Detect if text looks like binary/Brotli gibberish rather than real content.
 
-        Returns True if the text has a high ratio of non-printable characters,
-        indicating it was stored from a compressed response that wasn't decoded.
+        BeautifulSoup converts binary data into Unicode characters that Python
+        considers 'printable' (accented letters, CJK, symbols). So we check for
+        non-ASCII ratio instead — real .gov web pages are overwhelmingly ASCII.
         """
         if not text or len(text) < 50:
             return False
         sample = text[:2000]
-        non_printable = sum(
-            1 for c in sample
-            if not c.isprintable() and c not in '\n\r\t'
-        )
-        ratio = non_printable / len(sample)
-        return ratio > 0.1  # More than 10% non-printable = garbage
+        non_ascii = sum(1 for c in sample if ord(c) > 127)
+        ratio = non_ascii / len(sample)
+        return ratio > 0.15  # More than 15% non-ASCII = garbage
 
     @staticmethod
     def compute_hash(text: str) -> str:


### PR DESCRIPTION
BeautifulSoup converts binary/Brotli data into Unicode characters that Python's isprintable() considers valid (accented letters, CJK, symbols). Switch to checking non-ASCII ratio — real .gov pages are overwhelmingly ASCII, while Brotli garbage has >50% non-ASCII characters.

https://claude.ai/code/session_01Jb4NMoDrVnbedqC1ePiMYn