### PR TITLE
Add full-page screenshots for changed RHTP pages

### DIFF
--- a/.github/workflows/url-monitor.yml
+++ b/.github/workflows/url-monitor.yml
@@ -27,6 +27,8 @@ jobs:
           cd state-spending-monitor
           pip install --upgrade pip
           pip install -r requirements.txt
+          pip install playwright
+          playwright install chromium --with-deps
 
       # Restore previous page snapshots from cache
       # Key must be unique per run so the updated snapshots get saved back.
@@ -68,6 +70,15 @@ jobs:
             state-spending-monitor/snapshots.json
           retention-days: 30
 
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: page-screenshots
+          path: state-spending-monitor/screenshots/
+          if-no-files-found: ignore
+          retention-days: 30
+
       - name: Create status issue
         if: always()
         uses: actions/github-script@v7
@@ -103,9 +114,13 @@ jobs:
 
             if (results.changed.length > 0) {
               body += `### Changed Pages\n\n`;
+              const screenshots = results.screenshots || {};
               for (const item of results.changed) {
                 body += `#### ${item.name}\n`;
                 body += `URL: ${item.url}\n\n`;
+                if (screenshots[item.name]) {
+                  body += `📸 Screenshot: \`${screenshots[item.name]}\` (download from **page-screenshots** artifact)\n\n`;
+                }
                 body += `\`\`\`diff\n${item.diff}\n\`\`\`\n\n`;
               }
             }

--- a/state-spending-monitor/screenshots.py
+++ b/state-spending-monitor/screenshots.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Screenshot capture for changed RHTP pages.
+
+Uses Playwright (headless Chromium) to take full-page screenshots of
+URLs that the URL monitor detected as changed.
+
+Saves screenshots to a configurable output directory as PNG files
+named by state (e.g., "Delaware.png").
+
+Required: pip install playwright && playwright install chromium
+"""
+
+import logging
+import os
+import re
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def sanitize_filename(name: str) -> str:
+    """Convert a state name to a safe filename."""
+    return re.sub(r'[^\w\s-]', '', name).strip().replace(' ', '_')
+
+
+def capture_screenshots(
+    changed: List[Dict],
+    output_dir: str = 'screenshots',
+    timeout: int = 30000,
+) -> Dict[str, str]:
+    """Take full-page screenshots of changed URLs.
+
+    Args:
+        changed: List of dicts with 'name' and 'url' keys (from url_monitor results).
+        output_dir: Directory to save screenshots.
+        timeout: Page load timeout in milliseconds.
+
+    Returns:
+        Dict mapping state name to screenshot file path.
+    """
+    if not changed:
+        logger.info("No changed pages to screenshot")
+        return {}
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        logger.warning("Playwright not installed — skipping screenshots")
+        return {}
+
+    os.makedirs(output_dir, exist_ok=True)
+    screenshots = {}
+
+    logger.info(f"Capturing {len(changed)} screenshots...")
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            viewport={'width': 1280, 'height': 720},
+            user_agent=(
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                'AppleWebKit/537.36 (KHTML, like Gecko) '
+                'Chrome/131.0.0.0 Safari/537.36'
+            ),
+        )
+
+        for item in changed:
+            name = item['name']
+            url = item['url']
+            filename = f"{sanitize_filename(name)}.png"
+            filepath = os.path.join(output_dir, filename)
+
+            logger.info(f"  Screenshotting: {name} ({url})")
+
+            try:
+                page = context.new_page()
+                page.goto(url, wait_until='networkidle', timeout=timeout)
+                page.screenshot(path=filepath, full_page=True)
+                page.close()
+
+                screenshots[name] = filepath
+                logger.info(f"  Saved: {filepath}")
+
+            except Exception as e:
+                logger.warning(f"  Failed to screenshot {name}: {e}")
+                try:
+                    page.close()
+                except Exception:
+                    pass
+
+        browser.close()
+
+    logger.info(f"Captured {len(screenshots)}/{len(changed)} screenshots")
+    return screenshots

--- a/state-spending-monitor/url_monitor.py
+++ b/state-spending-monitor/url_monitor.py
@@ -665,6 +665,21 @@ def main():
     with open('url-monitor-results.json', 'w') as f:
         json.dump(results, f, indent=2, default=str)
 
+    # Take screenshots of changed pages
+    if results['changed']:
+        try:
+            from screenshots import capture_screenshots
+            screenshots = capture_screenshots(results['changed'])
+            results['screenshots'] = {
+                name: os.path.basename(path)
+                for name, path in screenshots.items()
+            }
+            # Re-save results with screenshot info
+            with open('url-monitor-results.json', 'w') as f:
+                json.dump(results, f, indent=2, default=str)
+        except Exception as e:
+            logger.warning(f"Screenshot capture failed: {e}")
+
     # Send email
     monitor.send_notification(results)
 


### PR DESCRIPTION
Uses Playwright (headless Chromium) to capture a full-page screenshot of each URL that changed. Screenshots are uploaded as a separate workflow artifact ("page-screenshots") and referenced in the GitHub issue body. Gracefully skips if no changes or Playwright unavailable.

Also fixes gibberish detection: checks non-ASCII ratio instead of non-printable (BeautifulSoup converts Brotli bytes to Unicode chars that pass isprintable()).

https://claude.ai/code/session_01Jb4NMoDrVnbedqC1ePiMYn