### PR TITLE
Add test and baseline screenshot modes to URL monitor workflow

### DIFF
--- a/.github/workflows/url-monitor.yml
+++ b/.github/workflows/url-monitor.yml
@@ -4,6 +4,20 @@ on:
   schedule:
     - cron: '0 9 * * *'  # Daily at 9:00 AM UTC
   workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Run mode'
+        required: false
+        default: 'monitor'
+        type: choice
+        options:
+          - monitor
+          - test
+          - baseline
+      test_url:
+        description: 'Test mode only: URL to screenshot'
+        required: false
+        default: ''
 
 permissions:
   issues: write
@@ -30,10 +44,10 @@ jobs:
           pip install playwright google-auth google-api-python-client
           playwright install chromium --with-deps
 
-      # Restore previous page snapshots from cache
-      # Key must be unique per run so the updated snapshots get saved back.
-      # restore-keys prefix-matches the most recent snapshot cache.
+      # ── Monitor mode (default + scheduled) ─────────────────────────
+
       - name: Restore snapshots cache
+        if: ${{ inputs.mode != 'test' && inputs.mode != 'baseline' }}
         uses: actions/cache@v4
         with:
           path: state-spending-monitor/snapshots.json
@@ -42,6 +56,7 @@ jobs:
             url-monitor-snapshots-
 
       - name: Run URL monitor
+        if: ${{ inputs.mode != 'test' && inputs.mode != 'baseline' }}
         env:
           MONDAY_API_TOKEN: ${{ secrets.MONDAY_API_TOKEN }}
           MONDAY_BOARD_ID: ${{ secrets.MONDAY_BOARD_ID }}
@@ -58,11 +73,8 @@ jobs:
           cd state-spending-monitor
           python url_monitor.py
 
-      # Save snapshots back to cache (always, even if monitor finds no changes)
-      # The cache action automatically saves on job completion using the same key
-
-      - name: Upload results
-        if: always()
+      - name: Upload monitor results
+        if: ${{ inputs.mode != 'test' && inputs.mode != 'baseline' && always() }}
         uses: actions/upload-artifact@v4
         with:
           name: url-monitor-results
@@ -72,17 +84,8 @@ jobs:
             state-spending-monitor/snapshots.json
           retention-days: 30
 
-      - name: Upload screenshots
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: page-screenshots
-          path: state-spending-monitor/screenshots/
-          if-no-files-found: ignore
-          retention-days: 30
-
       - name: Create status issue
-        if: always()
+        if: ${{ inputs.mode != 'test' && inputs.mode != 'baseline' && always() }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -157,3 +160,39 @@ jobs:
               title, body, labels
             });
             console.log(`Created issue: ${title}`);
+
+      # ── Test mode ──────────────────────────────────────────────────
+
+      - name: Test screenshot + Drive upload
+        if: ${{ inputs.mode == 'test' }}
+        env:
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+        run: |
+          cd state-spending-monitor
+          python test_screenshot.py --url "${{ inputs.test_url }}"
+
+      # ── Baseline mode ──────────────────────────────────────────────
+
+      - name: Capture baseline screenshots of all 51 states
+        if: ${{ inputs.mode == 'baseline' }}
+        env:
+          MONDAY_API_TOKEN: ${{ secrets.MONDAY_API_TOKEN }}
+          MONDAY_BOARD_ID: ${{ secrets.MONDAY_BOARD_ID }}
+          MONDAY_URL_COLUMN_ID: ${{ secrets.MONDAY_URL_COLUMN_ID }}
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+        run: |
+          cd state-spending-monitor
+          python test_screenshot.py --baseline
+
+      # ── Screenshots artifact (all modes) ───────────────────────────
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: page-screenshots
+          path: state-spending-monitor/screenshots/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/state-spending-monitor/test_screenshot.py
+++ b/state-spending-monitor/test_screenshot.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Test and baseline screenshot utility.
+
+Modes:
+  --url <url>     Test mode: screenshot one URL, upload to Drive
+  --baseline      Baseline mode: screenshot all 51 RHTP state URLs from
+                  monday.com and upload to Drive in a dated subfolder
+
+Reuses screenshots.py and drive_upload.py.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+)
+logger = logging.getLogger(__name__)
+
+
+def test_single_url(url: str):
+    """Screenshot a single URL and upload to Drive."""
+    from screenshots import capture_screenshots
+    from drive_upload import upload_screenshots_to_drive
+
+    items = [{'name': 'Test', 'url': url}]
+    screenshots = capture_screenshots(items)
+
+    if not screenshots:
+        logger.error("Screenshot capture failed")
+        sys.exit(1)
+
+    logger.info(f"Screenshot saved: {list(screenshots.values())[0]}")
+
+    folder_id = os.getenv('GOOGLE_DRIVE_FOLDER_ID', '')
+    creds = os.getenv('GOOGLE_SERVICE_ACCOUNT_JSON', '')
+    if folder_id and creds:
+        links = upload_screenshots_to_drive(screenshots, folder_id, creds)
+        for name, link in links.items():
+            print(f"\nDrive link: {link}")
+    else:
+        logger.info("Drive credentials not set — screenshot saved locally only")
+
+
+def baseline_all():
+    """Screenshot all 51 RHTP URLs from monday.com."""
+    from url_monitor import URLMonitor
+    from screenshots import capture_screenshots
+    from drive_upload import upload_screenshots_to_drive
+
+    monitor = URLMonitor()
+    urls = monitor.fetch_urls_from_monday()
+    if not urls:
+        logger.error("No URLs found on monday.com board")
+        sys.exit(1)
+
+    logger.info(f"Taking baseline screenshots of {len(urls)} URLs...")
+
+    # Use dated output dir
+    date_str = datetime.now().strftime('%Y-%m-%d')
+    output_dir = f'screenshots/baseline-{date_str}'
+    screenshots = capture_screenshots(urls, output_dir=output_dir, timeout=45000)
+
+    logger.info(f"Captured {len(screenshots)}/{len(urls)} screenshots")
+
+    # Upload to Drive in a dated subfolder
+    folder_id = os.getenv('GOOGLE_DRIVE_FOLDER_ID', '')
+    creds = os.getenv('GOOGLE_SERVICE_ACCOUNT_JSON', '')
+    if folder_id and creds:
+        subfolder = f"Baseline {date_str}"
+        links = upload_screenshots_to_drive(
+            screenshots, folder_id, creds, subfolder_name=subfolder,
+        )
+        print(f"\n{'='*60}")
+        print(f"BASELINE SCREENSHOTS — {date_str}")
+        print(f"{'='*60}")
+        print(f"Uploaded {len(links)}/{len(urls)} to Drive subfolder: {subfolder}")
+        for name, link in sorted(links.items()):
+            print(f"  {name}: {link}")
+    else:
+        logger.info("Drive credentials not set — screenshots saved locally only")
+
+    # Write summary for GitHub Actions
+    summary_file = os.getenv('GITHUB_STEP_SUMMARY')
+    if summary_file:
+        with open(summary_file, 'a') as f:
+            f.write(f"# Baseline Screenshots — {date_str}\n\n")
+            f.write(f"Captured **{len(screenshots)}** of **{len(urls)}** state pages\n\n")
+            if folder_id and creds:
+                f.write("| State | Drive Link |\n|-------|------------|\n")
+                for name, link in sorted(links.items()):
+                    f.write(f"| {name} | [View]({link}) |\n")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test/baseline screenshot utility')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--url', help='Screenshot a single test URL')
+    group.add_argument('--baseline', action='store_true', help='Screenshot all 51 state URLs')
+    args = parser.parse_args()
+
+    if args.url:
+        test_single_url(args.url)
+    elif args.baseline:
+        baseline_all()


### PR DESCRIPTION
Three workflow_dispatch modes:
- monitor (default): normal daily run, screenshots only for changes
- test: screenshot a single URL, upload to Drive, verify integration
- baseline: screenshot all 51 state URLs, upload to Drive subfolder named "Baseline YYYY-MM-DD"

Test/baseline modes skip the URL monitor entirely — no cache touch, no monday.com status updates, no GitHub issues created.

https://claude.ai/code/session_01Jb4NMoDrVnbedqC1ePiMYn