### PR TITLE
Harden workflows and URL monitor security guardrails

### DIFF
--- a/.github/workflows/dress-monitor.yml
+++ b/.github/workflows/dress-monitor.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -43,7 +43,7 @@ jobs:
 
     - name: Upload monitoring logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: monitor-logs-${{ github.run_number }}
         path: |
@@ -53,7 +53,7 @@ jobs:
 
     - name: Create Issue if dress found
       if: hashFiles('dress-monitor/findings.json') != ''
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/fix-board-urls.yml
+++ b/.github/workflows/fix-board-urls.yml
@@ -20,15 +20,15 @@ jobs:
   fix-urls:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install requests
+        run: pip install requests==2.32.5
 
       - name: Fix board URLs
         working-directory: state-spending-monitor

--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install requests beautifulsoup4 lxml pypdf
+        run: pip install requests==2.32.5 beautifulsoup4==4.13.4 lxml==5.4.0 pypdf==5.9.0
 
       - name: Generate briefing report
         working-directory: state-spending-monitor
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload newsletter draft
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: newsletter-draft
           path: |
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create newsletter issue
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/state-spending-monitor.yml
+++ b/.github/workflows/state-spending-monitor.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c
         with:
           python-version: '3.11'
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: official-sources-results
           path: |
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create status issue
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const fs = require('fs');
@@ -155,10 +155,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c
         with:
           python-version: '3.11'
 
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: news-sources-results
           path: |
@@ -189,7 +189,7 @@ jobs:
 
       - name: Create status issue
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/test-email.yml
+++ b/.github/workflows/test-email.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
         python-version: '3.11'
 

--- a/.github/workflows/url-monitor.yml
+++ b/.github/workflows/url-monitor.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c
         with:
           python-version: '3.11'
 
@@ -41,14 +41,14 @@ jobs:
           cd state-spending-monitor
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install playwright google-auth google-api-python-client
+          pip install playwright==1.55.0 google-auth==2.40.3 google-api-python-client==2.179.0
           playwright install chromium --with-deps
 
       # ── Monitor mode (default + scheduled) ─────────────────────────
 
       - name: Restore snapshots cache
         if: ${{ inputs.mode != 'test' && inputs.mode != 'baseline' }}
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: state-spending-monitor/snapshots.json
           key: url-monitor-snapshots-${{ github.run_id }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload monitor results
         if: ${{ inputs.mode != 'test' && inputs.mode != 'baseline' && always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: url-monitor-results
           path: |
@@ -86,7 +86,7 @@ jobs:
 
       - name: Create status issue
         if: ${{ inputs.mode != 'test' && inputs.mode != 'baseline' && always() }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const fs = require('fs');
@@ -190,7 +190,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: page-screenshots
           path: state-spending-monitor/screenshots/

--- a/.github/workflows/validate-urls.yml
+++ b/.github/workflows/validate-urls.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c
         with:
           python-version: '3.11'
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: validation-results
           path: |
@@ -59,7 +59,7 @@ jobs:
 
       - name: Create report issue
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const fs = require('fs');

--- a/state-spending-monitor/LAUNCH_BLOG_FEATURES.md
+++ b/state-spending-monitor/LAUNCH_BLOG_FEATURES.md
@@ -1,0 +1,108 @@
+# State Spending Monitor: Launch Blog Feature Summary
+
+## What it is
+State Spending Monitor is an automated intelligence pipeline for tracking Rural Health Transformation Program (RHTP) activity across all 50 U.S. states. It combines official government sources, media monitoring, board-driven URL surveillance, and automated reporting to help teams detect, validate, and communicate changes quickly.
+
+## Core monitoring capabilities
+
+### 1) 50-state RHTP news monitoring (`monitor.py`)
+- Monitors **all 50 states** with built-in state mappings.
+- Supports three source modes:
+  - `official` (CMS, HHS, and state health departments)
+  - `news` (Google News RSS)
+  - `all` (default, combines both)
+- Pulls from multiple federal and state endpoints, including:
+  - CMS newsroom feeds (with fallback feed URL patterns)
+  - CMS and HHS pages via direct scraping
+  - State health department news pages for every state
+  - State-specific Google News RSS queries
+- Includes resilient HTTP behavior:
+  - retry/backoff for transient failures
+  - browser-like headers for higher compatibility
+  - proxy-environment isolation for CI stability
+
+### 2) Relevance and signal quality filtering
+- Uses RHTP-focused keyword matching plus broader rural-health/funding context matching.
+- Requires state mention matching (abbreviation/full name) for geographic relevance.
+- Applies lookback windows for freshness filtering.
+- Tracks source success/error stats to monitor feed health over time.
+
+### 3) Deduplication and historical persistence
+- Prevents duplicate findings across runs.
+- Writes cumulative results to `findings.json`.
+- Produces execution logs in `monitor.log`.
+- Generates run summaries and status payloads suitable for automation/reporting.
+
+### 4) Notification workflows
+- Sends SMTP email alerts for findings and/or run status.
+- Supports configurable notification behavior through environment variables.
+- Formats human-readable result digests for rapid triage.
+
+## URL lifecycle operations (board-driven)
+
+### 5) monday.com-powered URL change monitoring (`url_monitor.py`)
+- Pulls monitored URLs directly from a monday.com board.
+- Supports URL column selection by ID/title with auto-detection fallback.
+- Can use item name as URL when configured.
+- Fetches pages, strips boilerplate HTML, and compares normalized text snapshots.
+- Detects meaningful change via hash + line-level diffs.
+- Filters trivial/noise-only changes (e.g., captcha churn/timestamp-only deltas).
+- Handles access-restricted pages (e.g., HTTP 403) as valid-but-undiffable states.
+- Persists snapshots to `snapshots.json` for day-over-day change tracking.
+- Updates monday.com status column (e.g., mark items Done when validated).
+
+### 6) URL validation and repair tooling (`validate_urls.py`)
+- Audits URL health from monday.com board entries.
+- Verifies reachability and checks for RHT-related content.
+- Can run in dry-run, report-only, or auto-fix mode.
+- Searches for replacement URLs when links break, with .gov preference heuristics.
+- Can write corrected links back to monday.com.
+
+### 7) One-time board patch utility (`fix_board_urls.py`)
+- Adds missing known state URLs and replaces known bad mappings.
+- Supports dry-run mode for safe preview.
+- Produces GitHub Actions summary output for operational transparency.
+
+## Visual and asset workflows
+
+### 8) Automated screenshots of changed pages (`screenshots.py`)
+- Uses Playwright (headless Chromium) to capture full-page screenshots of changed URLs.
+- Saves state-named PNG artifacts in a configurable output directory.
+- Returns a map of state → screenshot path for downstream automation.
+
+### 9) Google Drive screenshot publishing (`drive_upload.py`)
+- Uploads screenshot artifacts to Google Drive via service account credentials.
+- Optionally creates date/run subfolders.
+- Sets files/folders to link-viewable and returns shareable URLs.
+- Enables direct embedding of visual evidence in issues and reports.
+
+## Reporting and editorial acceleration
+
+### 10) Weekly newsletter briefing generator (`newsletter.py`)
+- Pulls weekly “page changed” issues from GitHub (`url-monitor` + `page-changed` labels).
+- Parses issue diffs, removes binary-garbage artifacts, and deduplicates by URL.
+- Re-fetches changed pages and follows key outbound links for richer context.
+- Optionally extracts PDF text when PDF tooling is available.
+- Pulls topic context from monday.com topics board.
+- Produces a structured briefing report intended for rapid newsletter drafting.
+- Saves output and posts to GitHub for asynchronous editorial workflows.
+
+## Operational readiness features
+
+### 11) CI/CD and automation-friendly design
+- Script-level CLI entry points for local and CI execution.
+- Environment-variable based configuration for secrets and runtime behavior.
+- Structured logs for troubleshooting (`monitor.log`, `url-monitor.log`, `validate-urls.log`).
+- Defensive dependency handling with clear install guidance on missing packages.
+
+### 12) Extensibility by design
+- Easy keyword/source updates in monitor configuration.
+- Modular components (monitoring, validation, screenshots, uploads, newsletter) can run independently or as a pipeline.
+- Designed to integrate with GitHub Actions artifacts/issues and external work-management systems (monday.com, Drive).
+
+## Launch positioning (blog-friendly framing)
+- **Comprehensive coverage:** all 50 states + federal sources + media aggregation.
+- **Actionable alerts:** not just collection, but change detection, validation, and notifications.
+- **Operational loop closure:** from data collection → diffing → screenshots → issue/report outputs.
+- **Editorial leverage:** transforms raw monitoring events into weekly narrative-ready briefings.
+- **Production pragmatism:** retries, fallback source handling, dedupe, and persistent state for dependable daily operation.

--- a/state-spending-monitor/README.md
+++ b/state-spending-monitor/README.md
@@ -80,6 +80,7 @@ Create a `.env` file or set these in GitHub Secrets:
 | `SMTP_USER` | SMTP username | Yes (if email enabled) | - |
 | `SMTP_PASSWORD` | SMTP password or app-specific password | Yes (if email enabled) | - |
 | `LOOKBACK_DAYS` | How many days to look back for news | No | `7` |
+| `URL_ALLOWED_DOMAIN_SUFFIXES` | Optional comma-separated allowlist for URL monitor host suffixes (e.g. `gov,cms.gov`) | No | empty (disabled) |
 
 ### Gmail Configuration
 

--- a/state-spending-monitor/requirements.txt
+++ b/state-spending-monitor/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.31.0
-beautifulsoup4>=4.12.0
-lxml>=5.0.0
-python-dotenv>=1.0.0
+requests==2.32.5
+beautifulsoup4==4.13.4
+lxml==5.4.0
+python-dotenv==1.1.1

--- a/state-spending-monitor/screenshots.py
+++ b/state-spending-monitor/screenshots.py
@@ -86,8 +86,8 @@ def capture_screenshots(
                 logger.warning(f"  Failed to screenshot {name}: {e}")
                 try:
                     page.close()
-                except Exception:
-                    pass
+                except Exception as close_err:
+                    logger.debug(f"Failed to close page cleanly after screenshot error: {close_err}")
 
         browser.close()
 

--- a/state-spending-monitor/url_monitor.py
+++ b/state-spending-monitor/url_monitor.py
@@ -24,8 +24,10 @@ import logging
 import difflib
 import re
 import time
+import ipaddress
 from datetime import datetime
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlparse
 import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -61,6 +63,7 @@ class URLMonitor:
         self.monday_url_column = os.getenv('MONDAY_URL_COLUMN_ID', '')
         self.monday_name_as_url = os.getenv('MONDAY_NAME_AS_URL', 'false').lower() == 'true'
         self.monday_status_column = os.getenv('MONDAY_STATUS_COLUMN', 'RHTP URL Status')
+        self.allowed_domain_suffixes = [s.strip().lower() for s in os.getenv('URL_ALLOWED_DOMAIN_SUFFIXES', '').split(',') if s.strip()]
 
         # Resolved at runtime by fetch_urls_from_monday()
         self._status_col_id = None
@@ -98,6 +101,47 @@ class URLMonitor:
         retry = Retry(total=3, backoff_factor=2, status_forcelist=[429, 500, 502, 503, 504])
         self.session.mount('https://', HTTPAdapter(max_retries=retry))
         self.session.mount('http://', HTTPAdapter(max_retries=retry))
+
+
+    def is_safe_target_url(self, url: str) -> bool:
+        """Allow only http(s) URLs that do not target local/private networks."""
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return False
+
+        if parsed.scheme not in ('http', 'https'):
+            return False
+
+        host = (parsed.hostname or '').strip().lower()
+        if not host:
+            return False
+
+        # Block localhost-like names
+        if host in {'localhost', 'localhost.localdomain'} or host.endswith('.local'):
+            return False
+
+        # If host is a literal IP, block private/reserved ranges
+        try:
+            ip = ipaddress.ip_address(host)
+            if any([
+                ip.is_private,
+                ip.is_loopback,
+                ip.is_link_local,
+                ip.is_reserved,
+                ip.is_multicast,
+                ip.is_unspecified,
+            ]):
+                return False
+        except ValueError:
+            # Hostname (not literal IP)
+            pass
+
+        # Optional allowlist: comma-separated domain suffixes (e.g. gov, cms.gov)
+        if self.allowed_domain_suffixes:
+            return any(host == suffix or host.endswith(f'.{suffix}') for suffix in self.allowed_domain_suffixes)
+
+        return True
 
     # ------------------------------------------------------------------
     # monday.com integration
@@ -238,7 +282,10 @@ class URLMonitor:
                                 break
 
                 if url:
-                    urls.append({'name': name, 'url': url, 'item_id': item_id})
+                    if self.is_safe_target_url(url):
+                        urls.append({'name': name, 'url': url, 'item_id': item_id})
+                    else:
+                        logger.warning(f"Skipping unsafe URL for item {name}: {url}")
                 else:
                     logger.warning(f"No URL found for item: {name}")
 
@@ -314,6 +361,10 @@ class URLMonitor:
         server responds with 403 (URL exists but blocks automated access).
         Returns None only on connection failures or 4xx/5xx other than 403.
         """
+        if not self.is_safe_target_url(url):
+            logger.warning(f"Blocked unsafe URL target: {url}")
+            return None
+
         try:
             resp = self.session.get(url, timeout=20, allow_redirects=True)
             if resp.status_code == 403:


### PR DESCRIPTION
### Motivation
- Reduce CI supply-chain risk by removing mutable action tags and making dependency resolution deterministic. 
- Prevent the URL-monitor from fetching internal/private hosts or other unsafe targets discovered via monday.com board entries. 
- Improve observability by avoiding silent exception swallowing during screenshot cleanup.

### Description
- Pinned GitHub Actions references across workflows to full commit SHAs (replaced `uses: actions/*@vX` with concrete SHAs) to reduce mutable-tag supply-chain risk. 
- Pinned Python dependencies in `state-spending-monitor/requirements.txt` and in relevant workflow `pip install` steps for deterministic installs (e.g. `requests==2.32.5`, `beautifulsoup4==4.13.4`, `playwright==1.55.0`, etc.).
- Added runtime URL safety guardrails to `state-spending-monitor/url_monitor.py` by introducing `self.allowed_domain_suffixes` (driven by `URL_ALLOWED_DOMAIN_SUFFIXES`), implementing `is_safe_target_url()` to block non-HTTP(s), localhost, and private/reserved IP targets, skipping unsafe monday.com URLs, and blocking fetches for unsafe targets before issuing HTTP requests. 
- Replaced a silent `except: pass` in `state-spending-monitor/screenshots.py` with a debug log to capture page-close failures, and documented the new `URL_ALLOWED_DOMAIN_SUFFIXES` env var in `state-spending-monitor/README.md`.

### Testing
- Ran syntax checks with `python -m py_compile state-spending-monitor/*.py` which completed successfully without compile errors. 
- Ran security scan `bandit -r state-spending-monitor -f txt` and fixed the single finding; final `bandit` run reported no issues. 
- Verified workflow changes via `rg -n "uses: actions/" .github/workflows/*.yml` to confirm action references were updated and inspected diffs to ensure pins were applied.
- Local functional checks included running the updated `url_monitor.py` static inspection and ensuring no runtime import errors after dependency pinning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699baeaeee44832f8f61620eb737d05c)