### PR TITLE
RHT: auto-refresh outlays.json in nightly build

### DIFF
--- a/.github/workflows/build-state-pages.yml
+++ b/.github/workflows/build-state-pages.yml
@@ -45,6 +45,17 @@ jobs:
           MONDAY_API_TOKEN: ${{ secrets.MONDAY_API_TOKEN }}
         run: python fetch_monday.py
 
+      # Refresh outlays.json for the /outlays/ page from the public USASpending
+      # API (obligated vs disbursed per state). No secrets — the --outlays-only
+      # path skips the Monday board and email. Non-fatal: if USASpending is down,
+      # build.py falls back to the last committed outlays.json.
+      - name: Refresh outlays.json from USASpending
+        working-directory: state-spending-monitor
+        continue-on-error: true
+        run: |
+          pip install requests==2.32.5
+          python spending_monitor.py --outlays-only
+
       # NOTE: procurements.json and dispatch_sources.json are intentionally NOT
       # produced or committed here — they are product data (RHTP Alerts feed /
       # paywalled newsletter content) and must never land in this public repo.
@@ -57,7 +68,7 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add work/rht/states state-spending-monitor/state_pages/states_data.json
+          git add work/rht/states state-spending-monitor/state_pages/states_data.json state-spending-monitor/state_pages/outlays.json
           if git diff --cached --quiet; then
             echo "No changes to commit."
           else


### PR DESCRIPTION
## What

The nightly `build-state-pages` workflow now refreshes `outlays.json` from the public USASpending API before it rebuilds the state pages, and commits the updated `outlays.json` alongside the regenerated HTML.

## Why

The `/work/rht/states/outlays/` page reads `outlays.json`, but nothing on `main` was refreshing that file — the full weekly `spending_monitor.py` runs in the private **RHT** repo, and the nightly build didn't commit `outlays.json`. So the page would have frozen at its launch numbers. This closes the loop entirely inside this repo.

## How

- New step runs `spending_monitor.py --outlays-only` — the dry-run path that hits **only the public USASpending API**: no Monday board, no email, **no secrets**. Just needs `pip install requests`.
- `continue-on-error: true` — if USASpending is unreachable, the nightly page rebuild still proceeds; `build.py` falls back to the last committed `outlays.json`.
- `outlays.json` added to the workflow's `git add`.

Net effect: the page's obligated/outlaid figures and `as_of` date refresh nightly, independent of the private RHT repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)