### PR TITLE
RHT: align Verified Daily Intelligence copy with signed scope

### DIFF
--- a/work/rht/intelligence/index.html
+++ b/work/rht/intelligence/index.html
@@ -13,11 +13,11 @@ gtag('config', 'G-H2EB005NB5');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Verified Daily Intelligence · RHT Data Consulting | Civic Operator</title>
-    <meta name="description" content="Verified Daily Intelligence is a per-client, human-verified morning digest of new $50B Rural Health Transformation opportunities matched to your rubric — each one checked, ranked, and paired with who to call. Your State Fit Brief, kept alive.">
+    <meta name="description" content="Verified Daily Intelligence is a per-client, human-verified digest of new $50B Rural Health Transformation opportunities matched to your rubric — most mornings, never fewer than twelve a month, each one checked by a person and paired with who to call. Your State Fit Brief, kept alive.">
     <link rel="icon" href="/favicon.ico">
 
     <meta property="og:title" content="Verified Daily Intelligence · RHT Data Consulting | Civic Operator">
-    <meta property="og:description" content="A per-client, human-verified morning digest of new RHTP opportunities matched to your organization — checked, ranked, and paired with who to call. From $2,000/mo.">
+    <meta property="og:description" content="A per-client, human-verified digest of new RHTP opportunities matched to your organization — checked by a person and paired with who to call. From $2,000/mo.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.civicoperator.com/work/rht/intelligence">
 
@@ -61,7 +61,7 @@ gtag('config', 'G-H2EB005NB5');
     <header class="header-section header-teal">
         <span class="eyebrow">RHT Data Consulting</span>
         <h1>Verified Daily Intelligence</h1>
-        <p class="lead">The opportunities that fit you — verified and delivered every morning, with who to call. Your State Fit Brief tells you where you fit once; this keeps that answer current.</p>
+        <p class="lead">The opportunities that fit you — verified by a person before they reach you, with who to call. Your State Fit Brief tells you where you fit once; this keeps that answer current.</p>
         <div class="d-flex gap-3 justify-content-center flex-wrap">
             <a href="mailto:danx@civicoperator.com?subject=Verified%20Daily%20Intelligence%20—%20scoped%20pilot" class="btn btn-primary btn-lg">Start a scoped pilot</a>
             <a href="#how" class="btn btn-light btn-lg">See what lands each morning</a>
@@ -89,7 +89,7 @@ gtag('config', 'G-H2EB005NB5');
                 <div class="col-md-4">
                     <div class="product">
                         <h3>What this is instead</h3>
-                        <p>The two or three things that fit <em>your</em> organization, checked by a human before they reach you, with the contacts and deadlines you need to act the same day. Judgment, not a dashboard.</p>
+                        <p>The two or three things that fit <em>your</em> organization, checked by a human before they reach you, with the contacts and deadlines the state has published. Judgment, not a dashboard.</p>
                     </div>
                 </div>
             </div>
@@ -99,8 +99,8 @@ gtag('config', 'G-H2EB005NB5');
     <!-- ===================== WHAT LANDS EACH MORNING ===================== -->
     <section class="section" id="how">
         <div class="container">
-            <h2>What lands in your inbox each morning</h2>
-            <p class="section-sub">A single, scannable digest — not per-alert spam. Every opportunity carries four things.</p>
+            <h2>What lands in your inbox</h2>
+            <p class="section-sub">A single, scannable digest — not per-alert spam. Every opportunity carries the first two. The rest come with it whenever the state has published them.</p>
             <div class="row g-4">
                 <div class="col-md-6 col-lg-3">
                     <div class="product">
@@ -120,18 +120,18 @@ gtag('config', 'G-H2EB005NB5');
                     <div class="product">
                         <span class="card-eyebrow">03</span>
                         <h3>The clock</h3>
-                        <p>Deadlines and where it sits in the state's timeline, so you know what's urgent and what can wait.</p>
+                        <p>Published deadlines and where the item sits in the state's timeline, so you know what's urgent and what can wait.</p>
                     </div>
                 </div>
                 <div class="col-md-6 col-lg-3">
                     <div class="product">
                         <span class="card-eyebrow">04</span>
                         <h3>Who to call</h3>
-                        <p>The relevant state contacts and the organizations already active on that topic, prioritized — so you're not starting from a blank page.</p>
+                        <p>The state contacts and the organizations already active on that topic, where the state has published them — so you're not starting from a blank page.</p>
                     </div>
                 </div>
             </div>
-            <p class="text-center mt-4 mb-0" style="max-width:760px;margin-left:auto;margin-right:auto;">One digest each morning. An occasional Friday text when something genuinely can't wait for Monday.</p>
+            <p class="text-center mt-4 mb-0" style="max-width:760px;margin-left:auto;margin-right:auto;">A digest most mornings — never fewer than twelve a month, and in practice a good deal more. When something genuinely can't wait, I'll text you.</p>
         </div>
     </section>
 
@@ -156,13 +156,13 @@ gtag('config', 'G-H2EB005NB5');
                 <div class="col-md-6">
                     <div class="product h-100">
                         <h3>Your criteria drive the match</h3>
-                        <p>We set up a private board with your fit criteria — your states, your topics, the kind of work you win. You edit it; the matcher follows it. As your strategy shifts, your digest shifts with it. No change orders, no waiting on me.</p>
+                        <p>We set up your fit criteria — your states, your topics, the kind of work you win. You direct changes; the matcher follows. As your strategy shifts, your digest shifts with it. No change orders, no waiting on me.</p>
                     </div>
                 </div>
                 <div class="col-md-6">
                     <div class="product h-100">
                         <h3>A running history you can search</h3>
-                        <p>Every opportunity you've ever been sent stays on your board as a searchable record — connected back to the master intelligence — so the pipeline you've been building doesn't vanish into old email.</p>
+                        <p>Every opportunity you've ever been sent stays on your record — connected back to the master intelligence — so the pipeline you've been building doesn't vanish into old email. It's yours on request at any time, and I open it up for direct access as the engagement settles in.</p>
                     </div>
                 </div>
             </div>
@@ -193,7 +193,7 @@ gtag('config', 'G-H2EB005NB5');
                     <div class="product" style="border:2px solid var(--co-purple);">
                         <span class="card-eyebrow">Verified Daily Intelligence</span>
                         <h3>Where you fit, every day</h3>
-                        <p>The Fit Brief kept alive — matched, verified, and turned into a daily list of what to do and who to call.</p>
+                        <p>The Fit Brief kept alive — matched, verified, and turned into a running list of what to do and who to call.</p>
                     </div>
                 </div>
             </div>
@@ -241,9 +241,10 @@ gtag('config', 'G-H2EB005NB5');
                         <div class="price">$2,000<small>/mo</small></div>
                         <div class="cadence">Scoped retainer · starting price</div>
                         <ul>
-                            <li>A daily, human-verified digest matched to your rubric</li>
-                            <li>Who-to-call enrichment and deadlines on every opportunity</li>
-                            <li>Your private, editable board with a searchable history</li>
+                            <li>A human-verified digest matched to your rubric, most mornings — never fewer than twelve a month</li>
+                            <li>What each opportunity is, why it fits you, and the source document, on every item</li>
+                            <li>Deadlines, state contacts, and who's already active, where the state has published them</li>
+                            <li>A running record of everything you've been sent, searchable and yours</li>
                             <li>Scales with the states you track, your rubric's breadth, and delivery cadence</li>
                         </ul>
                         <a href="mailto:danx@civicoperator.com?subject=Verified%20Daily%20Intelligence%20—%20scoped%20pilot" class="btn btn-primary w-100">Start a scoped pilot</a>


### PR DESCRIPTION
Rewrites the commitment sentences on /work/rht/intelligence so the promise on the page matches the signed scope.

- Daily → "most mornings" with a twelve-per-month floor
- Board access described as maintained / provided on request, not a shipped feature
- Deadlines, contacts, and priority qualified to "where the state has published"
- Meta + og:description brought in line

Left intact: the human-verification promise, the firehose contrast, and the unstated non-exclusivity handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)