### PR TITLE
RHT: second pass on Verified Daily Intelligence copy vs signed scope

### DIFF
--- a/work/rht/intelligence/index.html
+++ b/work/rht/intelligence/index.html
@@ -151,7 +151,7 @@ gtag('config', 'G-H2EB005NB5');
     <section class="section">
         <div class="container">
             <h2>Tuned to your rubric — and it stays yours</h2>
-            <p class="section-sub">One private board, set to your criteria, that follows your strategy as it changes.</p>
+            <p class="section-sub">Your criteria, your record — set to how you actually sell, and yours to take with you.</p>
             <div class="row g-4 justify-content-center">
                 <div class="col-md-6">
                     <div class="product h-100">
@@ -192,7 +192,7 @@ gtag('config', 'G-H2EB005NB5');
                 <div class="col-md-4">
                     <div class="product" style="border:2px solid var(--co-purple);">
                         <span class="card-eyebrow">Verified Daily Intelligence</span>
-                        <h3>Where you fit, every day</h3>
+                        <h3>Where you fit, kept current</h3>
                         <p>The Fit Brief kept alive — matched, verified, and turned into a running list of what to do and who to call.</p>
                     </div>
                 </div>
@@ -209,13 +209,13 @@ gtag('config', 'G-H2EB005NB5');
                 <div class="col-md-4">
                     <div class="product">
                         <h3>Vendors &amp; platforms</h3>
-                        <p>Companies selling into rural health that need to know the moment a fundable opportunity opens in a state they care about.</p>
+                        <p>Companies selling into rural health that need to know when a fundable opportunity opens in a state they care about.</p>
                     </div>
                 </div>
                 <div class="col-md-4">
                     <div class="product">
                         <h3>Resellers &amp; partners</h3>
-                        <p>Teams representing multiple products or channels who need a prioritized, per-rubric feed rather than a generic firehose.</p>
+                        <p>Teams representing multiple products or channels who need a feed built to their own rubric rather than a generic firehose.</p>
                     </div>
                 </div>
                 <div class="col-md-4">
@@ -259,7 +259,7 @@ gtag('config', 'G-H2EB005NB5');
     <section class="cta" id="contact">
         <div class="container">
             <h2>Start a scoped pilot</h2>
-            <p class="lead mb-4">Tell me your target states and what you sell. I'll stand up your board, tune the rubric, and run a short pilot so you can see the digests before you commit.</p>
+            <p class="lead mb-4">Tell me your target states and what you sell. I'll tune the rubric and run a short pilot so you can see the digests before you commit.</p>
             <div class="d-flex gap-3 justify-content-center flex-wrap">
                 <a href="mailto:danx@civicoperator.com?subject=Verified%20Daily%20Intelligence%20—%20scoped%20pilot" class="btn btn-primary btn-lg">Email me to scope a pilot</a>
                 <a href="https://calendar.app.google/XruT8HoUjnKLCkwD8" class="btn btn-light btn-lg">Book a conversation</a>


### PR DESCRIPTION
Clears the five remaining pre-scale-back phrases on /work/rht/intelligence.

- Board subhead → "Your criteria, your record… yours to take with you"
- Pilot CTA: "stand up your board" removed
- Vendors: "the moment" → "when" (no real-time framing)
- Resellers: "prioritized" removed
- Ladder third rung: "every day" → "kept current"

Left intact: human-verification promise, firehose contrast, unstated non-exclusivity, and the product name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)