### PR TITLE
VDI intelligence page: sharpen "who to call" copy

### DIFF
--- a/work/rht/intelligence/index.html
+++ b/work/rht/intelligence/index.html
@@ -127,7 +127,7 @@ gtag('config', 'G-H2EB005NB5');
                     <div class="product">
                         <span class="card-eyebrow">04</span>
                         <h3>Who to call</h3>
-                        <p>The state contacts and the organizations already active on that topic, where the state has published them — so you're not starting from a blank page.</p>
+                        <p>The state contacts, subrecipients, awardees, and other organizations already active on that topic, where the state has published them — so you're not starting from a blank page.</p>
                     </div>
                 </div>
             </div>
@@ -243,7 +243,7 @@ gtag('config', 'G-H2EB005NB5');
                         <ul>
                             <li>A human-verified digest matched to your rubric, most mornings — never fewer than twelve a month</li>
                             <li>What each opportunity is, why it fits you, and the source document, on every item</li>
-                            <li>Deadlines, state contacts, and who's already active, where the state has published them</li>
+                            <li>Deadlines, detailed subrecipient and awardee contact info, and other meaningful lead info you can act on today</li>
                             <li>A running record of everything you've been sent, searchable and yours</li>
                             <li>Scales with the states you track, your rubric's breadth, and delivery cadence</li>
                         </ul>


### PR DESCRIPTION
Two small copy edits on the Verified Daily Intelligence page (`/work/rht/intelligence`), per DXO:

- **Card 04 "Who to call"** now names subrecipients and awardees explicitly, not just state contacts.
- **Pricing card bullet** now reads "Deadlines, detailed subrecipient and awardee contact info, and other meaningful lead info you can act on today."

No structural or styling changes — one file, two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)