### PR TITLE
RHT subnav: add missing Daily Intelligence link across all sections

### DIFF
--- a/state-spending-monitor/state_pages/build.py
+++ b/state-spending-monitor/state_pages/build.py
@@ -184,6 +184,7 @@ SUBNAV = """<div class="rht-subnav">
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/activity/index.html
+++ b/work/rht/activity/index.html
@@ -86,6 +86,7 @@ body{margin:0;background:#fff;}
   <a href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch active" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/additional/index.html
+++ b/work/rht/additional/index.html
@@ -50,6 +50,7 @@ gtag('config', 'G-H2EB005NB5');
         <a href="/work/rht/states">State profiles</a>
         <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
         <a class="active" href="/work/rht/brief">Consulting</a>
+        <a href="/work/rht/intelligence">Daily Intelligence</a>
         <span class="arch-sep">·</span>
         <a class="arch" href="/work/rht/activity">Activity Index</a>
         <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/brief/index.html
+++ b/work/rht/brief/index.html
@@ -50,6 +50,7 @@ gtag('config', 'G-H2EB005NB5');
         <a href="/work/rht/states">State profiles</a>
         <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
         <a class="active" href="/work/rht/brief" aria-current="page">Consulting</a>
+        <a href="/work/rht/intelligence">Daily Intelligence</a>
         <span class="arch-sep">·</span>
         <a class="arch" href="/work/rht/activity">Activity Index</a>
         <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/dashboard/index.html
+++ b/work/rht/dashboard/index.html
@@ -200,6 +200,7 @@ body{margin:0;}
   <a href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch active" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/agencies/index.html
+++ b/work/rht/states/agencies/index.html
@@ -230,6 +230,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/alabama/index.html
+++ b/work/rht/states/alabama/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/alaska/index.html
+++ b/work/rht/states/alaska/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/arizona/index.html
+++ b/work/rht/states/arizona/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/arkansas/index.html
+++ b/work/rht/states/arkansas/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/california/index.html
+++ b/work/rht/states/california/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/colorado/index.html
+++ b/work/rht/states/colorado/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/connecticut/index.html
+++ b/work/rht/states/connecticut/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/delaware/index.html
+++ b/work/rht/states/delaware/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/florida/index.html
+++ b/work/rht/states/florida/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/georgia/index.html
+++ b/work/rht/states/georgia/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/hawaii/index.html
+++ b/work/rht/states/hawaii/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/idaho/index.html
+++ b/work/rht/states/idaho/index.html
@@ -410,6 +410,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/illinois/index.html
+++ b/work/rht/states/illinois/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/index.html
+++ b/work/rht/states/index.html
@@ -491,6 +491,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/indiana/index.html
+++ b/work/rht/states/indiana/index.html
@@ -385,6 +385,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/iowa/index.html
+++ b/work/rht/states/iowa/index.html
@@ -410,6 +410,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/kansas/index.html
+++ b/work/rht/states/kansas/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/kentucky/index.html
+++ b/work/rht/states/kentucky/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/louisiana/index.html
+++ b/work/rht/states/louisiana/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/maine/index.html
+++ b/work/rht/states/maine/index.html
@@ -415,6 +415,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/maryland/index.html
+++ b/work/rht/states/maryland/index.html
@@ -405,6 +405,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/massachusetts/index.html
+++ b/work/rht/states/massachusetts/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/methodology/index.html
+++ b/work/rht/states/methodology/index.html
@@ -237,6 +237,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/michigan/index.html
+++ b/work/rht/states/michigan/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/minnesota/index.html
+++ b/work/rht/states/minnesota/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/mississippi/index.html
+++ b/work/rht/states/mississippi/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/missouri/index.html
+++ b/work/rht/states/missouri/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/montana/index.html
+++ b/work/rht/states/montana/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/nebraska/index.html
+++ b/work/rht/states/nebraska/index.html
@@ -385,6 +385,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/nevada/index.html
+++ b/work/rht/states/nevada/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/new-hampshire/index.html
+++ b/work/rht/states/new-hampshire/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/new-jersey/index.html
+++ b/work/rht/states/new-jersey/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/new-mexico/index.html
+++ b/work/rht/states/new-mexico/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/new-york/index.html
+++ b/work/rht/states/new-york/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/north-carolina/index.html
+++ b/work/rht/states/north-carolina/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/north-dakota/index.html
+++ b/work/rht/states/north-dakota/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/ohio/index.html
+++ b/work/rht/states/ohio/index.html
@@ -395,6 +395,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/oklahoma/index.html
+++ b/work/rht/states/oklahoma/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/oregon/index.html
+++ b/work/rht/states/oregon/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/outlays/index.html
+++ b/work/rht/states/outlays/index.html
@@ -230,6 +230,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/pennsylvania/index.html
+++ b/work/rht/states/pennsylvania/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/rhode-island/index.html
+++ b/work/rht/states/rhode-island/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/rural-definitions/index.html
+++ b/work/rht/states/rural-definitions/index.html
@@ -230,6 +230,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/south-carolina/index.html
+++ b/work/rht/states/south-carolina/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/south-dakota/index.html
+++ b/work/rht/states/south-dakota/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/tennessee/index.html
+++ b/work/rht/states/tennessee/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/texas/index.html
+++ b/work/rht/states/texas/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/utah/index.html
+++ b/work/rht/states/utah/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/vermont/index.html
+++ b/work/rht/states/vermont/index.html
@@ -405,6 +405,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/virginia/index.html
+++ b/work/rht/states/virginia/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/washington/index.html
+++ b/work/rht/states/washington/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/west-virginia/index.html
+++ b/work/rht/states/west-virginia/index.html
@@ -400,6 +400,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/wisconsin/index.html
+++ b/work/rht/states/wisconsin/index.html
@@ -405,6 +405,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>

--- a/work/rht/states/wyoming/index.html
+++ b/work/rht/states/wyoming/index.html
@@ -350,6 +350,7 @@ body{margin:0;background:#fff;}
   <a class="active" href="/work/rht/states">State profiles</a>
   <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
   <a href="/work/rht/brief">Consulting</a>
+  <a href="/work/rht/intelligence">Daily Intelligence</a>
   <span class="arch-sep">&middot;</span>
   <a class="arch" href="/work/rht/activity">Activity Index</a>
   <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>


### PR DESCRIPTION
## Problem
Off the RHT root, the section nav looked incomplete/inconsistent: the **Daily Intelligence** tab appeared only on `/work/rht` and `/work/rht/intelligence`. Every other section — State profiles, Consulting, all 50 state profiles, methodology/agencies/outlays/rural-definitions, activity, dashboard, additional — rendered a subnav missing that tab.

## Fix
- **Generator** (`build.py` `SUBNAV`): added the link so future weekly regenerations of the state/reference pages include it.
- **Committed HTML (59 pages)**: applied the identical surgical insertion so it goes live now without waiting for the rebuild. Only the subnav block is touched — no content or dates changed. (Local regeneration was avoided on purpose: it would stamp today's date site-wide and, with `procurements.json` being CI-only, would drop procurement data.)

Color scheme already matched across page types (`#005f75` teal bar, white pills) — the perceived scheme mismatch was just the absent tab.

## Follow-up needed
`activity/` and `dashboard/` are produced by **external generators not in this repo**. Their committed HTML is patched here, but those generators' own subnav templates still need the same one-line addition or they'll regress on the next rebuild.