### PR TITLE
Rename product to "RHTP Verified Intelligence"; nav label to "Intelligence"

### DIFF
--- a/work/rht/index.html
+++ b/work/rht/index.html
@@ -13,7 +13,7 @@ gtag('config', 'G-H2EB005NB5');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Rural Health Transformation | Civic Operator</title>
-    <meta name="description" content="Everything on the $50B CMS Rural Health Transformation Program in three layers: a free state-by-state reference, the Grant Tracker newsletter, and consulting — from a one-time State Fit Brief to Verified Daily Intelligence, a per-client, human-verified morning digest of RHTP opportunities.">
+    <meta name="description" content="Everything on the $50B CMS Rural Health Transformation Program in three layers: a free state-by-state reference, the Grant Tracker newsletter, and consulting — from a one-time State Fit Brief to RHTP Verified Intelligence, a per-client, human-verified morning digest of RHTP opportunities.">
     <link rel="icon" href="/favicon.ico">
 
     <meta property="og:title" content="Rural Health Transformation | Civic Operator">
@@ -50,7 +50,7 @@ gtag('config', 'G-H2EB005NB5');
         <a href="/work/rht/states">State profiles</a>
         <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
         <a href="/work/rht/brief">Consulting</a>
-        <a href="/work/rht/intelligence">Daily Intelligence</a>
+        <a href="/work/rht/intelligence">Intelligence</a>
         <span class="arch-sep">·</span>
         <a class="arch" href="/work/rht/activity">Activity Index</a>
         <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>
@@ -94,7 +94,7 @@ gtag('config', 'G-H2EB005NB5');
                 </div>
                 <div class="layer-card">
                     <span class="layer-tag">The subscription — operate</span>
-                    <h3>Verified Daily Intelligence</h3>
+                    <h3>RHTP Verified Intelligence</h3>
                     <p>Your State Fit Brief, kept alive. Every morning: the new RHTP opportunities that match your organization — each one checked by a human, ranked, and paired with who to call. <a href="/work/rht/intelligence">See how it works</a>.</p>
                     <div class="layer-foot">
                         <a href="/work/rht/intelligence" class="btn btn-primary layer-cta">Start a scoped pilot →</a>
@@ -111,7 +111,7 @@ gtag('config', 'G-H2EB005NB5');
             <div class="fit-gateway-card">
                 <span class="fit-kicker">The gateway — customize</span>
                 <h3>Start with a one-time State Fit Brief</h3>
-                <p>Before you go daily, get the map. A one-time, ranked <strong>State Fit Brief</strong> shows where your organization fits the program across up to ten states — matched dollars, procurement windows, enabling legislation, and named contacts. It's the point-in-time analysis most clients start with, and the on-ramp to <a href="/work/rht/intelligence">Verified Daily Intelligence</a>.</p>
+                <p>Before you go daily, get the map. A one-time, ranked <strong>State Fit Brief</strong> shows where your organization fits the program across up to ten states — matched dollars, procurement windows, enabling legislation, and named contacts. It's the point-in-time analysis most clients start with, and the on-ramp to <a href="/work/rht/intelligence">RHTP Verified Intelligence</a>.</p>
                 <div class="d-flex gap-3 justify-content-center flex-wrap">
                     <a href="/work/rht/brief" class="btn btn-light">See what's in a brief — $480</a>
                 </div>
@@ -126,7 +126,7 @@ gtag('config', 'G-H2EB005NB5');
             <a href="/work/rht/states">State profiles</a> &nbsp;·&nbsp;
             <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a> &nbsp;·&nbsp;
             <a href="/work/rht/brief">Consulting</a> &nbsp;·&nbsp;
-            <a href="/work/rht/intelligence">Daily Intelligence</a> &nbsp;·&nbsp;
+            <a href="/work/rht/intelligence">Intelligence</a> &nbsp;·&nbsp;
             <a href="/work/rht/additional">Additional Briefs</a> &nbsp;·&nbsp;
             <a href="/work/rht/activity">Activity Index</a> &nbsp;·&nbsp;
             <a href="/work/rht/dashboard">Quarterly Report</a> &nbsp;·&nbsp;

--- a/work/rht/intelligence/index.html
+++ b/work/rht/intelligence/index.html
@@ -12,11 +12,11 @@ gtag('config', 'G-H2EB005NB5');
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Verified Daily Intelligence · RHT Data Consulting | Civic Operator</title>
-    <meta name="description" content="Verified Daily Intelligence is a per-client, human-verified digest of new $50B Rural Health Transformation opportunities matched to your rubric — most mornings, never fewer than twelve a month, each one checked by a person and paired with who to call. Your State Fit Brief, kept alive.">
+    <title>RHTP Verified Intelligence · RHT Data Consulting | Civic Operator</title>
+    <meta name="description" content="RHTP Verified Intelligence is a per-client, human-verified digest of new $50B Rural Health Transformation opportunities matched to your rubric — most mornings, never fewer than twelve a month, each one checked by a person and paired with who to call. Your State Fit Brief, kept alive.">
     <link rel="icon" href="/favicon.ico">
 
-    <meta property="og:title" content="Verified Daily Intelligence · RHT Data Consulting | Civic Operator">
+    <meta property="og:title" content="RHTP Verified Intelligence · RHT Data Consulting | Civic Operator">
     <meta property="og:description" content="A per-client, human-verified digest of new RHTP opportunities matched to your organization — checked by a person and paired with who to call. From $2,000/mo.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.civicoperator.com/work/rht/intelligence">
@@ -50,20 +50,20 @@ gtag('config', 'G-H2EB005NB5');
         <a href="/work/rht/states">State profiles</a>
         <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a>
         <a href="/work/rht/brief">Consulting</a>
-        <a class="active" href="/work/rht/intelligence" aria-current="page">Daily Intelligence</a>
+        <a class="active" href="/work/rht/intelligence" aria-current="page">Intelligence</a>
         <span class="arch-sep">·</span>
         <a class="arch" href="/work/rht/activity">Activity Index</a>
         <a class="arch" href="/work/rht/dashboard">Quarterly Report</a>
     </div>
-    <nav class="crumbs" aria-label="Breadcrumb"><a href="/">Home</a><span class="sep">&rsaquo;</span><a href="/work/rht">RHT</a><span class="sep">&rsaquo;</span><span>Verified Daily Intelligence</span></nav>
+    <nav class="crumbs" aria-label="Breadcrumb"><a href="/">Home</a><span class="sep">&rsaquo;</span><a href="/work/rht">RHT</a><span class="sep">&rsaquo;</span><span>RHTP Verified Intelligence</span></nav>
 
     <!-- ===================== HERO ===================== -->
     <header class="header-section header-teal">
         <span class="eyebrow">RHT Data Consulting</span>
-        <h1>Verified Daily Intelligence</h1>
+        <h1>RHTP Verified Intelligence</h1>
         <p class="lead">The opportunities that fit you — verified by a person before they reach you, with who to call. Your State Fit Brief tells you where you fit once; this keeps that answer current.</p>
         <div class="d-flex gap-3 justify-content-center flex-wrap">
-            <a href="mailto:danx@civicoperator.com?subject=Verified%20Daily%20Intelligence%20—%20scoped%20pilot" class="btn btn-primary btn-lg">Start a scoped pilot</a>
+            <a href="mailto:danx@civicoperator.com?subject=RHTP%20Verified%20Intelligence%20—%20scoped%20pilot" class="btn btn-primary btn-lg">Start a scoped pilot</a>
             <a href="#how" class="btn btn-light btn-lg">See what lands each morning</a>
         </div>
     </header>
@@ -191,7 +191,7 @@ gtag('config', 'G-H2EB005NB5');
                 </div>
                 <div class="col-md-4">
                     <div class="product" style="border:2px solid var(--co-purple);">
-                        <span class="card-eyebrow">Verified Daily Intelligence</span>
+                        <span class="card-eyebrow">RHTP Verified Intelligence</span>
                         <h3>Where you fit, kept current</h3>
                         <p>The Fit Brief kept alive — matched, verified, and turned into a running list of what to do and who to call.</p>
                     </div>
@@ -237,7 +237,7 @@ gtag('config', 'G-H2EB005NB5');
                 <div class="col-lg-6">
                     <div class="price-card featured">
                         <span class="badge-featured">The standing subscription</span>
-                        <h3>Verified Daily Intelligence</h3>
+                        <h3>RHTP Verified Intelligence</h3>
                         <div class="price">$2,000<small>/mo</small></div>
                         <div class="cadence">Scoped retainer · starting price</div>
                         <ul>
@@ -247,7 +247,7 @@ gtag('config', 'G-H2EB005NB5');
                             <li>A running record of everything you've been sent, searchable and yours</li>
                             <li>Scales with the states you track, your rubric's breadth, and delivery cadence</li>
                         </ul>
-                        <a href="mailto:danx@civicoperator.com?subject=Verified%20Daily%20Intelligence%20—%20scoped%20pilot" class="btn btn-primary w-100">Start a scoped pilot</a>
+                        <a href="mailto:danx@civicoperator.com?subject=RHTP%20Verified%20Intelligence%20—%20scoped%20pilot" class="btn btn-primary w-100">Start a scoped pilot</a>
                     </div>
                 </div>
             </div>
@@ -261,7 +261,7 @@ gtag('config', 'G-H2EB005NB5');
             <h2>Start a scoped pilot</h2>
             <p class="lead mb-4">Tell me your target states and what you sell. I'll tune the rubric and run a short pilot so you can see the digests before you commit.</p>
             <div class="d-flex gap-3 justify-content-center flex-wrap">
-                <a href="mailto:danx@civicoperator.com?subject=Verified%20Daily%20Intelligence%20—%20scoped%20pilot" class="btn btn-primary btn-lg">Email me to scope a pilot</a>
+                <a href="mailto:danx@civicoperator.com?subject=RHTP%20Verified%20Intelligence%20—%20scoped%20pilot" class="btn btn-primary btn-lg">Email me to scope a pilot</a>
                 <a href="https://calendar.app.google/XruT8HoUjnKLCkwD8" class="btn btn-light btn-lg">Book a conversation</a>
             </div>
             <p class="mt-4 mb-0">Or reach me directly: <a href="mailto:danx@civicoperator.com" style="color:#fff;text-decoration:underline;">danx@civicoperator.com</a> &nbsp;·&nbsp; <a href="tel:+17739606045" style="color:#fff;text-decoration:underline;">(773) 960-6045</a></p>
@@ -275,7 +275,7 @@ gtag('config', 'G-H2EB005NB5');
             <a href="/work/rht/states">State profiles</a> &nbsp;·&nbsp;
             <a href="https://www.ruralhealthtransformation.life/" target="_blank" rel="noopener">Newsletter</a> &nbsp;·&nbsp;
             <a href="/work/rht/brief">Consulting</a> &nbsp;·&nbsp;
-            <a href="/work/rht/intelligence">Daily Intelligence</a> &nbsp;·&nbsp;
+            <a href="/work/rht/intelligence">Intelligence</a> &nbsp;·&nbsp;
             <a href="/work/rht/additional">Additional Briefs</a> &nbsp;·&nbsp;
             <a href="/work/rht/activity">Activity Index</a> &nbsp;·&nbsp;
             <a href="/work/rht/dashboard">Quarterly Report</a> &nbsp;·&nbsp;


### PR DESCRIPTION
Per DXO, rebrand the product on the funnel's end page:

- **Product name**: "Verified Daily Intelligence" → **"RHTP Verified Intelligence"** — updated in the page `<title>`, OG title, meta description, breadcrumb, H1, the ladder card, the pricing card, and the mailto subjects. Also updated the two references on the RHT hub page (`/work/rht`).
- **Nav label**: sub-nav and footer link shortened from "Daily Intelligence" → **"Intelligence"** on both pages.

Two files, no structural/style changes. Prose uses of "daily"/"morning" left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)